### PR TITLE
change the provider of exam.js.cool

### DIFF
--- a/main/active_cname.js
+++ b/main/active_cname.js
@@ -62,7 +62,7 @@ module.exports = {
   //'jen': 'dirkhe1051931999.github.io',
   'uiw': 'uiwjs.github.io',
   'shu': '87a5f664-7619-4689-b0d8-3cf0d028a6d3.id.repl.co',
-  'exam': 'exam-clock.vercel.app', //noCf
+  'exam': 'examined.netlify.app',
   'xrkffgg': 'xrkffgg.github.io',
   'interview': 'front-end-interview.netlify.app',
   'xiaomeiwu':'xiaomeiwu.github.io',


### PR DESCRIPTION
- [x] 申请该域名有实际的用途
- [x] 我已经阅读并遵守限定条款

---

<!-- 在下方简单描述域名的用途
 Introduce how to use the subdomain blow -->

我是[ExamClockArchieve](https://github.com/L33Z22L11/ExamClockArchive)项目的持有者，这个项目是一个适用于校园考试的大屏时间网页，由于vercel项目使用的exam-clock.vercel.app不可访问，所以更换到了netlify。