### PR TITLE
feat: ip.js.cool 使用 vercel 提供给大陆专用的 dns cname

### DIFF
--- a/main/active_cname.js
+++ b/main/active_cname.js
@@ -69,7 +69,7 @@ module.exports = {
   'xiaopi': 'xiaopi.netlify.app',
   'xiaowang': 'xiaowang.netlify.app',
   'love': 'sincere.vercel.app',// noCF
-  'ip': 'ipip.vercel.app', // noCF
+  'ip': 'cname-china.vercel-dns.com', // noCF
   'mingyan': 'lehs8n.coding-pages.com', //noCf
   'na': 'qq.mcust.cn',
   'rx': 'willin.github.io',


### PR DESCRIPTION
- [x] 申请该域名有实际的用途
- [x] 我已经阅读并遵守限定条款

---

<!-- 在下方简单描述域名的用途
 Introduce how to use the subdomain blow -->

原 cname 大陆不能访问， vercel 提供了大陆专用的 dns cname